### PR TITLE
Fix unmoveable blocks in invisible filter after recycling window

### DIFF
--- a/Mcasaenk/Colormap/ColorMapping.cs
+++ b/Mcasaenk/Colormap/ColorMapping.cs
@@ -21,6 +21,8 @@ namespace Mcasaenk.Colormaping {
         public readonly TintManager TintManager;
         public readonly FilterManager FilterManager;
 
+        public HashSet<ushort> AlwaysInvis = [];
+
         public Colormap(RawColormap rawmap, int world_version, DatapacksInfo datapacksInfo) {
 
             ushort PLAINSBIOME = 0;
@@ -67,6 +69,7 @@ namespace Mcasaenk.Colormaping {
 
                     if(b.Value.color.A < 255) {
                         FilterManager.Invis._AddBlock(id);
+                        AlwaysInvis.Add(id);
                     }
                 }
 
@@ -105,6 +108,7 @@ namespace Mcasaenk.Colormaping {
                     foreach(var block in f.blocks) {
                         if(Block.TryGetId(block.minecraftname(), out ushort id)) {
                             FilterManager.AddBlock(id, filter);
+                            if (filter == FilterManager.Invis) AlwaysInvis.Add(id);
                         }
                     }
                 }

--- a/Mcasaenk/UI/LeftSettingsMenu.xaml.cs
+++ b/Mcasaenk/UI/LeftSettingsMenu.xaml.cs
@@ -31,7 +31,7 @@ namespace Mcasaenk.UI {
                 var blocks = colormap.Block.All().Select(n => {
                     Filter blockfilter = colormap.FilterManager.Elements.FirstOrDefault(t => t.Blocks.Contains(n.Key));/* = colormap.TintManager.GetBlockVal(n.Key);*/
                     BinaryBlockGroupWindow.Group group = BinaryBlockGroupWindow.Group.Def;
-                    if(blockfilter == colormap.FilterManager.Invis) group = BinaryBlockGroupWindow.Group.AlwaysThis;
+                    if(blockfilter == colormap.FilterManager.Invis) group = colormap.AlwaysInvis.Contains(n.Key) ? BinaryBlockGroupWindow.Group.AlwaysThis : BinaryBlockGroupWindow.Group.This;
                     //else if(blockfilter != null && blockfilter != colormap.FilterManager.Default) group = BinaryBlockGroupWindow.Group.Other;
 
                     return (n.Value, true, group);


### PR DESCRIPTION
I recently stumbled upon this excellent project and have found the renders it produces very aesthetically pleasing.

However, I noticed a minor issue where, after adding to the *Invisible blocks* filter, you can no longer remove those blocks when reopening the filter window.

Looking through the code, it seems to be that the `Colormap` class doesn't keep track of which blocks are always supposed to be invisible and thus unmoveable. Therefore, when `LeftSettingsMenu` opens the *Invisible filter* window again, all the currently filtered blocks are unmoveable including any non-air/barrier blocks that were added before. Since the alpha values for all blocks are or'd with 0xFF, there seems to be no way to differentiate always invisible blocks and ones added to the filter by the user.

Adding a block to the filter - block can be moved back:
<img width="586" height="443" alt="Screenshot 2026-02-24 170012" src="https://github.com/user-attachments/assets/a25a2f40-c49c-4ba3-bcc6-28dc79d787b0" />

After closing and reopening the filter - block is unmoveable:
<img width="586" height="443" alt="Screenshot 2026-02-24 170151" src="https://github.com/user-attachments/assets/e28e6429-5b04-456d-9b52-18d1839932ee" />

This PR adds a public HashSet of always invisible block IDs to the `Colormap` class which is filled at instantiation. It's then used by `LeftSettingsMenu` to determine whether rows in the selected column should be moveable or not.

After closing and reopening the filter (with these changes):
<img width="586" height="443" alt="Screenshot 2026-02-24 170025" src="https://github.com/user-attachments/assets/feb7a7f7-06fb-469c-a842-34a2592c3ae2" />

I tested the changes and captured the above screenshots in VS with .NET 8.